### PR TITLE
Adds iOS hotspot interfaces support

### DIFF
--- a/UIDevice_Extended.mm
+++ b/UIDevice_Extended.mm
@@ -36,8 +36,9 @@ SCNetworkConnectionFlags connectionFlags;
 				NSString *name = @(cursor->ifa_name);
                 
                 NSPredicate * isMatchWIFIInterfaceName = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"en\\d+"];
+				NSPredicate * isMatchHotspotInterfaceName = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"bridge\\d+"];
 
-				if ([isMatchWIFIInterfaceName evaluateWithObject:name])  // Wi-Fi adapter
+				if ([isMatchWIFIInterfaceName evaluateWithObject:name] || [isMatchHotspotInterfaceName evaluateWithObject:name])  // Wi-Fi or Hotspot adapter
                 {
 					wifiIPAddress = [NSString stringWithUTF8String:
                                      (inet_ntoa(((struct sockaddr_in *)cursor->ifa_addr)->sin_addr))];

--- a/UIDevice_Extended.mm
+++ b/UIDevice_Extended.mm
@@ -36,7 +36,7 @@ SCNetworkConnectionFlags connectionFlags;
 				NSString *name = @(cursor->ifa_name);
                 
                 NSPredicate * isMatchWIFIInterfaceName = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"en\\d+"];
-				NSPredicate * isMatchHotspotInterfaceName = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"bridge\\d+"];
+                NSPredicate * isMatchHotspotInterfaceName = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", @"bridge\\d+"];
 
 				if ([isMatchWIFIInterfaceName evaluateWithObject:name] || [isMatchHotspotInterfaceName evaluateWithObject:name])  // Wi-Fi or Hotspot adapter
                 {


### PR DESCRIPTION
This PR adds hotspot (bridge) interfaces to be recognised alongside WiFi interfaces.
Handy to be used when tethering from iPhone to iPads (with autoconfigure pac).